### PR TITLE
Feature/2025 09 24/3 hamiltonian str

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ LocalPreferences.toml
 JuliaLocalPreferences.toml
 
 .vscode/
+memo.*

--- a/example/double-pendulum.jl
+++ b/example/double-pendulum.jl
@@ -1,6 +1,6 @@
 # using Latexify
 
-include("main.jl")
+include("../src/main.jl")
 
 @variables t
 n = 2

--- a/example/double-pendulum.jl
+++ b/example/double-pendulum.jl
@@ -1,5 +1,3 @@
-# using Latexify
-
 include("../src/main.jl")
 
 @variables t

--- a/example/double-pendulum.jl
+++ b/example/double-pendulum.jl
@@ -1,3 +1,5 @@
+# using Latexify
+
 include("main.jl")
 
 @variables t
@@ -18,5 +20,7 @@ q_to_x = [
 
 T = (1//2) * q_dot[1]^2 + (1//2) * m * (q_dot[1]^2 + r^2 * q_dot[2]^2 + 2 * r * cos(q[1] - q[2]) * q_dot[1] * q_dot[2])
 V = -g * cos(q[1]) - m * g * (cos(q[1]) + r * cos(q[2]))
-Lexp = T - V
-lag = Lagrangian(t, q, q_dot, Lexp, q_to_x)
+Lexp = T - V # |> expand_derivatives |> simplify
+lag = Lagrangian(t, q, q_dot, Lexp, q_to_x);
+
+ham = hamiltonian(lag);

--- a/example/double-pendulum.jl
+++ b/example/double-pendulum.jl
@@ -19,6 +19,6 @@ q_to_x = [
 T = (1//2) * q_dot[1]^2 + (1//2) * m * (q_dot[1]^2 + r^2 * q_dot[2]^2 + 2 * r * cos(q[1] - q[2]) * q_dot[1] * q_dot[2])
 V = -g * cos(q[1]) - m * g * (cos(q[1]) + r * cos(q[2]))
 Lexp = T - V # |> expand_derivatives |> simplify
-lag = Lagrangian(t, q, q_dot, Lexp, q_to_x);
+lag = Lagrangian(t, q, q_dot, Lexp, q_to_x)
 
-ham = hamiltonian(lag);
+ham = hamiltonian(lag)

--- a/example/pendulum.jl
+++ b/example/pendulum.jl
@@ -1,0 +1,24 @@
+# using Latexify
+
+include("../src/main.jl")
+
+@variables t
+n = 1
+@variables (q(t))[1:n]
+D = Differential(t)
+q_dot = D.(q)
+
+@parameters g
+
+@variables (x(t))[1:2]
+q_to_x = [
+    sin(q[1]),
+    cos(q[1]),
+]
+
+T = (1//2) * q_dot[1]^2
+V = -g * cos(q[1])
+Lexp = T - V # |> expand_derivatives |> simplify
+lag = Lagrangian(t, q, q_dot, Lexp, q_to_x);
+
+ham = hamiltonian(lag);

--- a/example/pendulum.jl
+++ b/example/pendulum.jl
@@ -1,5 +1,3 @@
-# using Latexify
-
 include("../src/main.jl")
 
 @variables t

--- a/example/pendulum.jl
+++ b/example/pendulum.jl
@@ -17,6 +17,6 @@ q_to_x = [
 T = (1//2) * q_dot[1]^2
 V = -g * cos(q[1])
 Lexp = T - V # |> expand_derivatives |> simplify
-lag = Lagrangian(t, q, q_dot, Lexp, q_to_x);
+lag = Lagrangian(t, q, q_dot, Lexp, q_to_x)
 
-ham = hamiltonian(lag);
+ham = hamiltonian(lag)

--- a/src/main.jl
+++ b/src/main.jl
@@ -66,10 +66,9 @@ function hamiltonian(lag::Lagrangian)
 
     q_dot_to_p_dict = Dict(q_dot[i] => e for (i, e) in enumerate(sol))
     H = sum(p[i] * q_dot[i] for i in 1:n) - L
-    H = substitute(H, q_dot_to_p_dict) # |> expand_derivatives |> simplify
+    H = substitute(H, q_dot_to_p_dict)
 
     p_to_qdot = sol .|> Num
-    # p_to_qdot = simplify(p_to_qdot)
 
     return Hamiltonian(t, q, p, H, q_to_x, p_to_qdot)
 end

--- a/src/main.jl
+++ b/src/main.jl
@@ -1,6 +1,7 @@
 # 解析力学を扱うためのモジュール
 
 using ModelingToolkit
+using Symbolics: derivative, solve_for, lhss, rhss
 
 """
     Lagrangian(t, q, q_dot, L, q_to_x=Vector{Num}())
@@ -15,6 +16,60 @@ struct Lagrangian
     q_to_x::Vector{Num} # 一般化座標から直交座標への変換関数を格納するベクトル
 
     function Lagrangian(t::Num, q::Symbolics.Arr{Num, 1}, q_dot::Symbolics.Arr{Num, 1}, L::Num, q_to_x::Vector{Num}=Vector{Num}())
-        new(t, q, q_dot, L, q_to_x)
+        new(t, q, q_dot, simplify(L), simplify.(q_to_x))
     end
+end
+
+"""
+    Hamiltonian(t, q, p, H, p_to_qdot=Vector{Num}())
+
+ハミルトニアンを表す構造体。
+"""
+struct Hamiltonian
+    t::Num
+    q::Symbolics.Arr{Num, 1}
+    p::Symbolics.Arr{Num, 1}
+    H::Num
+    q_to_x::Vector{Num} # 一般化座標から直交座標への変換関数を格納するベクトル
+    p_to_qdot::Vector{Num} # 一般化運動量 p と速度 ̇q の関係関数を格納するベクトル
+
+    function Hamiltonian(t::Num, q::Symbolics.Arr{Num, 1}, p::Symbolics.Arr{Num, 1}, H::Num, q_to_x::Vector{Num}=Vector{Num}(), p_to_qdot::Vector{Num}=Vector{Num}())
+        new(t, q, p, simplify(H), simplify.(q_to_x), simplify.(p_to_qdot))
+    end
+end
+
+function hamiltonian(lag::Lagrangian)
+    t = lag.t
+    q = lag.q
+    q_dot = lag.q_dot
+    L = lag.L
+    q_to_x = lag.q_to_x
+
+    n = length(q)
+    @variables (p(t))[1:n]
+
+    p_expr = [expand_derivatives(derivative(L, q_dot[i])) |> simplify for i in 1:n]
+
+    # ̇q を (q, p) で解く
+    eqs = [p[i] ~ p_expr[i] for i in 1:n]
+    sol = solve_for(eqs, q_dot)
+
+    # solve_for が失敗する場合は線形系として解く (T が2次形式の場合など)
+    if isempty(sol)
+        M = [expand_derivatives(derivative(p[i], q_dot[j])) |> simplify for i in 1:n, j in 1:n]
+        try
+            sol = inv(M) * collect(p)
+        catch e
+            throw(ErrorException("Legendre変換に失敗しました。ラグランジアンが速度に退化しているか、拘束条件が適切設定されていない可能性があります。"))
+        end
+    end
+
+    q_dot_to_p_dict = Dict(q_dot[i] => e for (i, e) in enumerate(sol))
+    H = sum(p[i] * q_dot[i] for i in 1:n) - L
+    H = substitute(H, q_dot_to_p_dict) # |> expand_derivatives |> simplify
+
+    p_to_qdot = sol .|> Num
+    # p_to_qdot = simplify(p_to_qdot)
+
+    return Hamiltonian(t, q, p, H, q_to_x, p_to_qdot)
 end

--- a/src/main.jl
+++ b/src/main.jl
@@ -56,7 +56,7 @@ function hamiltonian(lag::Lagrangian)
 
     # solve_for が失敗する場合は線形系として解く (T が2次形式の場合など)
     if isempty(sol)
-        M = [expand_derivatives(derivative(p[i], q_dot[j])) |> simplify for i in 1:n, j in 1:n]
+        M = [expand_derivatives(derivative(p_expr[i], q_dot[j])) |> simplify for i in 1:n, j in 1:n]
         try
             sol = inv(M) * collect(p)
         catch e

--- a/src/main.jl
+++ b/src/main.jl
@@ -1,7 +1,7 @@
 # 解析力学を扱うためのモジュール
 
 using ModelingToolkit
-using Symbolics: derivative, solve_for, lhss, rhss
+using Symbolics: derivative, solve_for
 
 """
     Lagrangian(t, q, q_dot, L, q_to_x=Vector{Num}())


### PR DESCRIPTION
## 📦 対応内容
#### 当プルリクエストの対応内容を記入してください。

- `Hamiltonian` 構造体を追加
- `Lagrangian` を受け取る `Hamiltonian` コンストラクタを追加
- `example` フォルダを作成し、`example.jl` を移動。その後 `double-pendulum.jl` に改名
- `example` に単振り子のデモンストレーションである `pendulum.jl` を追加

## 🔗 関連Issue

- Closes #3

## 👤 レビュアーへの補足（自由記述）
- `Symbolics.jl` には以前 `differenciate` という関数があったようですが現在は `derivative` に名前が変更されています

## ✅ チェックリスト
- [x] 修正したコードは動作確認まで済んでいる。
- [x] 上記の関連issueが `Closes #<issue番号>` の形式で入力済みである。<br>
※ 上記の形式で入力しないと、マージ時にissueが自動でクローズできません
- [x] その他、[コントリビューションガイド](./CONTRIBUTING.md) に沿って対応できていることを確認した。
